### PR TITLE
Use local golangci-lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,10 @@ jobs:
           go-version: '1.18'
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.45
-          args: --timeout=5m
+        run: make lint
 
       - name: Run go tests and generate coverage report
-        run: make coverge
+        run: make coverage
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage.out
+.tools/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all: lint test
 PHONY: test coverage lint golint clean vendor
+
 GOOS=linux
+TOOLS_DIR := .tools
+GOLANGCI_LINT_VERSION = v1.45.2
 
 .PHONY: test coverage lint golint vendor clean
 
@@ -16,15 +19,29 @@ coverage:
 
 lint: golint
 
-golint: | vendor
+golint: | vendor $(TOOLS_DIR)/golangci-lint
 	@echo Linting Go files...
-	@golangci-lint run
+	@$(TOOLS_DIR)/golangci-lint run
 
 clean:
 	@echo Cleaning...
 	@rm -rf coverage.out
 	@go clean -testcache
+	@rm -r $(TOOLS_DIR)
 
 vendor:
 	@go mod download
 	@go mod tidy
+
+# Tools setup
+$(TOOLS_DIR):
+	mkdir -p $(TOOLS_DIR)
+
+$(TOOLS_DIR)/golangci-lint: $(TOOLS_DIR)
+	export \
+		VERSION=$(GOLANGCI_LINT_VERSION) \
+		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
+		BINDIR=$(TOOLS_DIR) && \
+	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
+	$(TOOLS_DIR)/golangci-lint version
+	$(TOOLS_DIR)/golangci-lint linters


### PR DESCRIPTION
The default GitHub actions settings we're able to set in this repo don't
allow us using external github actions. While we fix this... we'll use
our own golangci-lint step.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
