### PR TITLE
WIP: Add initial `audittail` implementation

### DIFF
--- a/cmds/audittail/cmd/common.go
+++ b/cmds/audittail/cmd/common.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 Equinix, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	ownerGroupOwnership = 0o640
+)
+
+func validateCommonArgs(cmd *cobra.Command, args []string) error {
+	f, ferr := cmd.Flags().GetString("file")
+
+	if ferr != nil {
+		return ferr
+	}
+
+	if f == "" {
+		return fmt.Errorf("--file is required")
+	}
+
+	return nil
+}
+
+func createNamedPipe(file string) error {
+	if err := syscall.Mkfifo(file, ownerGroupOwnership); err != nil {
+		return fmt.Errorf("creating named pipe: %w", err)
+	}
+	return nil
+}

--- a/cmds/audittail/cmd/common_test.go
+++ b/cmds/audittail/cmd/common_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 Equinix, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateCommonArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name: "should succeed",
+			args: []string{
+				"-f", "foo",
+			},
+			wantErr: false,
+		},
+		{
+			name: "should fail with empty file path",
+			args: []string{
+				"-f", "",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "should fail without arguments",
+			args:    []string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewRootCmd()
+			c.SetArgs(tt.args)
+			perr := c.ParseFlags(tt.args)
+			require.NoError(t, perr)
+			err := validateCommonArgs(c, tt.args)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func Test_validateCommonArgsFailsWithoutArguments(t *testing.T) {
+	t.Parallel()
+
+	c := &cobra.Command{}
+	err := validateCommonArgs(c, []string{})
+	require.Error(t, err)
+}

--- a/cmds/audittail/cmd/init.go
+++ b/cmds/audittail/cmd/init.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022 Equinix, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// initCmd represents the init command.
+var initCmd = NewInitCommand()
+
+func NewInitCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Initialize an audit log file to tail",
+		Long: `Initialize an audit log file to tail.
+
+This initializes an audit log file as a named pipe in order to tail it.
+This is useful to run in an init container to ensure the file is ready.`,
+		Args: cobra.MatchAll(cobra.OnlyValidArgs, validateCommonArgs),
+		RunE: initTailFile,
+	}
+}
+
+// nolint:gochecknoinits // this is a practice recommended by cobra
+func init() {
+	rootCmd.AddCommand(initCmd)
+}
+
+func initTailFile(cmd *cobra.Command, args []string) error {
+	//nolint:errcheck // This is already verified by cobra
+	f, _ := cmd.Flags().GetString("file")
+
+	if err := createNamedPipe(f); err != nil {
+		return err
+	}
+
+	_, werr := fmt.Fprintf(cmd.OutOrStdout(), "Created named pipe %s\n", f)
+	if werr != nil {
+		return fmt.Errorf("writing to stdout: %w", werr)
+	}
+
+	return nil
+}

--- a/cmds/audittail/cmd/init_test.go
+++ b/cmds/audittail/cmd/init_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2022 Equinix, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		args               []string
+		appendAuditLogFile bool
+		wantErr            bool
+	}{
+		{
+			name: "should initialize pipe",
+			args: []string{
+				"init", "-f",
+			},
+			appendAuditLogFile: true,
+			wantErr:            false,
+		},
+		{
+			name: "no arguments should fail",
+			args: []string{
+				"init",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewRootCmd()
+			buf := bytes.NewBufferString("")
+			c.SetOutput(buf)
+			c.AddCommand(NewInitCommand())
+
+			args := tt.args
+			var path string
+
+			if tt.appendAuditLogFile {
+				tmpDir := t.TempDir()
+				path = filepath.Join(tmpDir, "audit.log")
+				args = append(args, path)
+			}
+
+			c.SetArgs(args)
+			err := c.Execute()
+			if tt.wantErr {
+				require.Error(t, err, "unexpected success")
+				return
+			}
+
+			require.NotEmpty(t, path, "path should not be empty")
+			require.NoError(t, err, "unexpected error")
+
+			_, serr := os.Stat(path)
+			require.NoError(t, serr, "unexpected error")
+			require.Contains(t, buf.String(), "Created named pipe")
+		})
+	}
+}
+
+func TestInitTailFileFailsIfItCantCreateFIFO(t *testing.T) {
+	t.Parallel()
+
+	// Initialize parent and sub-command. This is useful to inherit
+	// the persistent flags.
+	c := NewRootCmd()
+	initCmd := NewInitCommand()
+	c.AddCommand(initCmd)
+
+	// Ensure buffered output in both commands
+	buf := bytes.NewBufferString("")
+	c.SetOutput(buf)
+	initCmd.SetOutput(buf)
+
+	// Set the arguments
+	tmpDir := t.TempDir()
+	args := append([]string{"-f"}, tmpDir)
+
+	perr := initCmd.ParseFlags(args)
+	require.NoError(t, perr)
+
+	err := initCmd.RunE(initCmd, args)
+	require.Error(t, err, "unexpected success")
+	require.Empty(t, buf.String(), "It should return an error and not write to stdout/err")
+}
+
+type errorWriter struct{}
+
+func (e *errorWriter) Write(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("error")
+}
+
+func TestInitTailFileFailsToWriteSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Initialize parent and sub-command. This is useful to inherit
+	// the persistent flags.
+	c := NewRootCmd()
+	initCmd := NewInitCommand()
+	c.AddCommand(initCmd)
+
+	// Create error from output
+	ew := &errorWriter{}
+	c.SetOutput(ew)
+	initCmd.SetOutput(ew)
+
+	// Set the arguments
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "audit.log")
+	args := append([]string{"-f"}, path)
+
+	perr := initCmd.ParseFlags(args)
+	require.NoError(t, perr)
+
+	err := initCmd.RunE(initCmd, args)
+	require.ErrorContains(t, err, "writing to stdout",
+		"there should be an error and it should contain the expected message")
+}

--- a/cmds/audittail/cmd/root.go
+++ b/cmds/audittail/cmd/root.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 Equinix, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// is the default time to wait in between audit log event reads.
+	defaultConstantBackoff = 5 * time.Millisecond
+)
+
+// rootCmd represents the base command when called without any subcommands.
+var rootCmd = NewRootCmd()
+
+func NewRootCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "audittail",
+		Short: "A utility to reliably tail audit an audit log file",
+		Long: `A utility to reliably tail audit an audit log file.
+	
+This utility will create a named pipe in order to tail the audit log file.`,
+		Args: cobra.MatchAll(cobra.OnlyValidArgs, validateCommonArgs),
+		RunE: tailMain,
+	}
+
+	c.PersistentFlags().StringP("file", "f", "", "audit log file to tail")
+	return c
+}
+
+func tailMain(cmd *cobra.Command, args []string) error {
+	//nolint:errcheck // This is already verified by cobra
+	f, _ := cmd.Flags().GetString("file")
+
+	if err := createNamedPipe(f); err != nil {
+		// If the file already exists this is not an issue.
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("creating named pipe: %w", err)
+		}
+	}
+
+	ft, err := newFileTailer(f, cmd.OutOrStdout())
+	if err != nil {
+		return fmt.Errorf("creating file tailer: %w", err)
+	}
+
+	return ft.tailFile(cmd.Context())
+}
+
+type fileTailer struct {
+	r io.Reader
+	w io.Writer
+}
+
+func newFileTailer(file string, w io.Writer) (*fileTailer, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, fmt.Errorf("opening file: %w", err)
+	}
+
+	return &fileTailer{
+		r: f,
+		w: w,
+	}, nil
+}
+
+func (ft *fileTailer) tailFile(ctx context.Context) error {
+	ticker := time.NewTicker(defaultConstantBackoff)
+	eg := &errgroup.Group{}
+	eg.Go(func() error {
+		for {
+			select {
+			case <-ticker.C:
+				if _, err := io.Copy(ft.w, ft.r); err != nil {
+					if !errors.Is(err, io.EOF) {
+						return err
+					}
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+
+	err := eg.Wait()
+	if err == nil || errors.Is(err, context.Canceled) {
+		return nil
+	}
+
+	return fmt.Errorf("tail file: %w", err)
+}

--- a/cmds/audittail/cmd/root_test.go
+++ b/cmds/audittail/cmd/root_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2022 Equinix, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeAuditEvent(t *testing.T, f *os.File, i int) {
+	t.Helper()
+	_, err := f.WriteString(fmt.Sprintf("audit-%d\n", i))
+	require.NoError(t, err, "Unexpected error writing audit event")
+}
+
+func generateAuditEvents(t *testing.T, path string, count int) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "unexpected error opening audit log file")
+	defer f.Close()
+
+	for i := 0; i < count; i++ {
+		writeAuditEvent(t, f, i)
+	}
+}
+
+// readAllAuditEvents reads all the events from the reader and fails if it times out
+// it will read 4 bytes at a time and count newlines to determine the amount of
+// audit events.
+func readAllAuditEvents(t *testing.T, reader io.Reader, expectedEvents int) {
+	t.Helper()
+	var count int
+	ticket := time.NewTicker(1 * time.Millisecond)
+
+	for {
+		select {
+		case <-ticket.C:
+			data := make([]byte, 4)
+			_, err := reader.Read(data)
+			// ignore EOF as the tail writer might not be ready with events
+			if len(data) == 0 || errors.Is(err, io.EOF) {
+				break
+			}
+			str := string(data)
+			count += strings.Count(str, "\n")
+			if count == expectedEvents {
+				return
+			}
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "timeout. We didn't receive all the events")
+		}
+	}
+}
+
+func TestTailWithoutArguments(t *testing.T) {
+	t.Parallel()
+
+	c := NewRootCmd()
+	buf := bytes.NewBufferString("")
+	c.SetOutput(buf)
+
+	args := []string{}
+
+	c.SetArgs(args)
+	err := c.Execute()
+	require.Error(t, err, "unexpected success")
+}
+
+func TestTailHappyPath(t *testing.T) {
+	t.Parallel()
+
+	// initialize command
+	c := NewRootCmd()
+
+	// initialize concurrent safe reader and writer
+	reader, writer := io.Pipe()
+	c.SetOutput(writer)
+
+	var path string
+
+	// initialize files
+	tmpDir := t.TempDir()
+	path = filepath.Join(tmpDir, "audit.log")
+
+	// set command line arguments
+	args := []string{"-f"}
+	args = append(args, path)
+	c.SetArgs(args)
+
+	// Events to write
+	numEvents := 100
+
+	// generate test events
+	var wg sync.WaitGroup
+	wg.Add(1)
+	func() {
+		defer wg.Done()
+		generateAuditEvents(t, path, numEvents)
+	}()
+
+	// Allow for cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Run command concurrently... this will block until we cancel it
+	ech := make(chan error)
+	go func(ech chan error) {
+		ech <- c.ExecuteContext(ctx)
+	}(ech)
+
+	// wait for all events to be written
+	wg.Wait()
+
+	// The audit file should exist
+	_, serr := os.Stat(path)
+	require.NoError(t, serr, "unexpected error")
+
+	// read all the events. Fails if it times out reading them
+	readAllAuditEvents(t, reader, numEvents)
+
+	// cancel the command (this should clear the go routine)
+	cancel()
+
+	err := <-ech
+	require.NoError(t, err, "unexpected error")
+	require.NotEmpty(t, path, "path should not be empty")
+}
+
+func TestRootFailsCreatingNamedPipe(t *testing.T) {
+	t.Parallel()
+
+	// Initialize parent and sub-command. This is useful to inherit
+	// the persistent flags.
+	c := NewRootCmd()
+
+	// Ensure buffered output in both commands
+	buf := bytes.NewBufferString("")
+	c.SetOutput(buf)
+
+	// create audit file
+	tmpDir := t.TempDir()
+	f, terr := ioutil.TempFile(tmpDir, "audit")
+	require.NoError(t, terr, "unexpected error creating temp file")
+
+	// No execute access so mkfifo will fail
+	cherr := os.Chmod(tmpDir, 0o600)
+	require.NoError(t, cherr, "unexpected error changing permissions")
+	// allow cleanup
+	defer func() {
+		cherr := os.Chmod(tmpDir, 0o700)
+		require.NoError(t, cherr, "unexpected error changing permissions")
+	}()
+
+	// Set the arguments.
+	args := append([]string{"-f"}, f.Name())
+	perr := c.ParseFlags(args)
+	require.NoError(t, perr, "unexpected error parsing flags")
+
+	err := c.RunE(c, args)
+	require.ErrorContains(t, err, "creating named pipe")
+	require.Empty(t, buf.String(), "It should return an error and not write to stdout/err")
+}
+
+func TestRootFailsCreatingTailer(t *testing.T) {
+	t.Parallel()
+
+	// Initialize parent and sub-command. This is useful to inherit
+	// the persistent flags.
+	c := NewRootCmd()
+
+	// Ensure buffered output in both commands
+	buf := bytes.NewBufferString("")
+	c.SetOutput(buf)
+
+	// create audit file
+	tmpDir := t.TempDir()
+	f, terr := ioutil.TempFile(tmpDir, "audit")
+	require.NoError(t, terr, "unexpected error creating temp file")
+
+	// write and execute, can't read
+	cherr := f.Chmod(0o300)
+	require.NoError(t, cherr, "unexpected error changing permissions")
+
+	// Set the arguments.
+	args := append([]string{"-f"}, f.Name())
+
+	perr := c.ParseFlags(args)
+	require.NoError(t, perr, "unexpected error parsing flags")
+
+	err := c.RunE(c, args)
+	require.ErrorContains(t, err, "creating file tailer")
+	require.Empty(t, buf.String(), "It should return an error and not write to stdout/err")
+}
+
+type errorReader struct{}
+
+func (e *errorReader) Read(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("error")
+}
+
+func TestFileTrailerUnknownErrorWhenTailing(t *testing.T) {
+	t.Parallel()
+
+	er := &errorReader{}
+	buf := bytes.NewBufferString("")
+	ft := &fileTailer{
+		r: er,
+		w: buf,
+	}
+
+	// trying to tail a reader that returns an unknown error should
+	// return immediately and should also surface the error
+	err := ft.tailFile(context.Background())
+	require.Error(t, err, "unexpected success")
+}

--- a/cmds/audittail/main.go
+++ b/cmds/audittail/main.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 Equinix, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"os"
+
+	"github.com/metal-toolbox/auditevent/cmds/audittail/cmd"
+)
+
+func main() {
+	c := cmd.NewRootCmd()
+	if err := c.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.18
 require (
 	github.com/gin-gonic/gin v1.7.7
 	github.com/google/uuid v1.3.0
+	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 require (
@@ -15,15 +17,17 @@ require (
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
 	github.com/golang/protobuf v1.3.3 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/ugorji/go/codec v1.1.7 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
-	gopkg.in/yaml.v2 v2.2.8 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -18,6 +19,8 @@ github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaW
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
@@ -30,6 +33,11 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -42,6 +50,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -53,7 +63,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
`audittail` is a command line utility that helps one tail audit logs.
It'll create and open the necessary named pipe and ensure to re-open
if there's an error.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
