### PR TITLE
Replace usages of `ioutil.TempDir` with `t.TempDir`

### DIFF
--- a/ginaudit/mdw_test.go
+++ b/ginaudit/mdw_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -123,12 +122,11 @@ func getTestCases() []testCase {
 func getNamedPipe(t *testing.T) string {
 	t.Helper()
 
-	dirName, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	dirName := t.TempDir()
 
 	pipeName := dirName + "/test.pipe"
 
-	err = syscall.Mkfifo(pipeName, 0o600)
+	err := syscall.Mkfifo(pipeName, 0o600)
 	require.NoError(t, err)
 
 	return pipeName
@@ -292,8 +290,7 @@ func TestOpenAuditLogFileUntilSuccess(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	tmpdir, err := ioutil.TempDir("", "ginaudit")
-	require.NoError(t, err)
+	tmpdir := t.TempDir()
 	tmpfile := filepath.Join(tmpdir, "audit.log")
 
 	go func() {
@@ -325,8 +322,7 @@ func TestOpenAuditLogFileError(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	tmpdir, err := ioutil.TempDir("", "ginaudit")
-	require.NoError(t, err)
+	tmpdir := t.TempDir()
 	tmpfile := filepath.Join(tmpdir, "audit.log")
 
 	go func() {

--- a/writer_test.go
+++ b/writer_test.go
@@ -3,7 +3,6 @@ package auditevent_test
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -17,12 +16,11 @@ import (
 func getNamedPipe(t *testing.T) string {
 	t.Helper()
 
-	dirName, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
+	dirName := t.TempDir()
 
 	pipeName := dirName + "/test.pipe"
 
-	err = syscall.Mkfifo(pipeName, 0o600)
+	err := syscall.Mkfifo(pipeName, 0o600)
 	require.NoError(t, err)
 
 	return pipeName


### PR DESCRIPTION
using the `TempDir` function that's available through the `testing.T`
structure, we're able to create temporary directories that get cleaned
out once the test ends. This is better than using `ioutil.TempDir` which
only gets cleaned out when the OS itself cleans the tmpfs.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
