### PR TITLE
Add audittail container image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 jobs:
-  golangci:
+  test:
     name: test
     runs-on: ubuntu-latest
     steps:
@@ -33,3 +33,20 @@ jobs:
           file: ./coverage.out
           flags: unittests
           name: codecov-umbrella
+
+  build-image:
+    name: build-image
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout 
+        uses: actions/checkout@v2
+      -
+        name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./images/audittail/Containerfile
+          push: false
+          tags: gchr.io/metal-toolbox/audittail:latest

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,27 @@
-all: lint test
-PHONY: test coverage lint golint clean vendor
+## Settings
 
+
+# Build Settings
 GOOS=linux
+
+# Utility settings
 TOOLS_DIR := .tools
 GOLANGCI_LINT_VERSION = v1.45.2
 
-.PHONY: test coverage lint golint vendor clean
+# Container build settings
+CONTAINER_BUILD_CMD?=docker build
+
+# Container settings
+CONTAINER_REPO?=ghcr.io/metal-toolbox
+AUDITTAIL_CONTAINER_IMAGE_NAME = $(CONTAINER_REPO)/audittail
+CONTAINER_TAG?=latest
+
+## Targets
+
+all: lint test
+PHONY: test coverage lint golint clean vendor
+
+.PHONY: test coverage lint golint vendor clean image audittail-image
 
 test: | lint
 	@echo Running unit tests...
@@ -32,6 +48,11 @@ clean:
 vendor:
 	@go mod download
 	@go mod tidy
+
+image: audittail-image
+
+audittail-image:
+	$(CONTAINER_BUILD_CMD) -f images/audittail/Containerfile . -t $(AUDITTAIL_CONTAINER_IMAGE_NAME):$(CONTAINER_TAG)
 
 # Tools setup
 $(TOOLS_DIR):

--- a/images/audittail/Containerfile
+++ b/images/audittail/Containerfile
@@ -1,0 +1,16 @@
+FROM docker.io/library/golang:1.18 as build-env
+
+WORKDIR /go/src/audittail
+
+# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build -o /go/bin/audittail cmds/audittail/main.go 
+
+FROM gcr.io/distroless/static
+
+COPY --from=build-env /go/bin/audittail /
+CMD ["/audittail"]

--- a/images/audittail/Containerfile.dockerignore
+++ b/images/audittail/Containerfile.dockerignore
@@ -1,0 +1,5 @@
+images/*
+.github/*
+.tools/*
+coverage.out
+*_test.go


### PR DESCRIPTION
This adds a simple container image that packages the `audittail` utility
into a minimal container. An appropriate Makefile tag and a Github
action to build this image was created.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
