### PR TITLE
Add function to set middleware and event type in one go

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -87,3 +87,14 @@ r.GET("/foo", myGetHandler)
 mdw.RegisterEventType("CreateFoo", http.MethodPost, "/foo")
 r.POST("/foo", myGetHandler)
 ```
+
+It's also possible to both set the audit middleware for a specific path and
+set a specific audit event type for the path:
+
+```golang
+router.GET("/user/:name", mdw.AuditWithType("GetUserInfo"), userInfoHandler)
+```
+
+**NOTE**: It is not recommended to assign a default or shared event type
+to all events as audit events need to be uniquely identifiable
+actions.


### PR DESCRIPTION
This is a usability enhancement which allows us to set the audit
middlewqrae and the event type in one function call. Note that it is
only recommended this be used on a specific path definition, as audit
events are not meant to be shared and should be uniquely identifiable.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
