### PR TITLE
audittail: React to SIGINT

### DIFF
--- a/cmds/audittail/cmd/root.go
+++ b/cmds/audittail/cmd/root.go
@@ -35,6 +35,10 @@ const (
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = NewRootCmd()
 
+func GetCmd() *cobra.Command {
+	return rootCmd
+}
+
 func NewRootCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "audittail",

--- a/cmds/audittail/cmd/root_test.go
+++ b/cmds/audittail/cmd/root_test.go
@@ -237,3 +237,10 @@ func TestFileTrailerUnknownErrorWhenTailing(t *testing.T) {
 	err := ft.tailFile(context.Background())
 	require.Error(t, err, "unexpected success")
 }
+
+func TestRootCmdSingletonGet(t *testing.T) {
+	t.Parallel()
+
+	c := GetCmd()
+	require.Equal(t, &rootCmd, &c, "GetCmd() should return the rootCmd singleton")
+}


### PR DESCRIPTION
The kubelet uses SIGINT to trigger shutdown of pods, this makes sure we
can appropriately react to it.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
