### PR TITLE
Introduce container image scan as part of build action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,14 +39,28 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout 
+      - name: Checkout 
         uses: actions/checkout@v2
-      -
-        name: Build
+
+      - name: Build
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./images/audittail/Containerfile
           push: false
           tags: gchr.io/metal-toolbox/audittail:latest
+
+      - name: Scan image
+        id: scan
+        uses: anchore/scan-action@v3
+        with:
+          image: gchr.io/metal-toolbox/audittail:latest
+          acs-report-enable: true
+
+      - name: upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+      
+      - name: Inspect action SARIF report
+        run: cat ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
This uses the `anchore/scan-action` [1] in order to scan container
images as soon as they're built (on each PR).

[1] https://github.com/marketplace/actions/anchore-container-scan

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
