### PR TITLE
Embed metrics in writer and middleware

### DIFF
--- a/cmds/audittail/cmd/init_test.go
+++ b/cmds/audittail/cmd/init_test.go
@@ -17,12 +17,13 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/metal-toolbox/auditevent/internal/testtools"
 )
 
 func TestInit(t *testing.T) {
@@ -112,12 +113,6 @@ func TestInitTailFileFailsIfItCantCreateFIFO(t *testing.T) {
 	require.Empty(t, buf.String(), "It should return an error and not write to stdout/err")
 }
 
-type errorWriter struct{}
-
-func (e *errorWriter) Write(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("error")
-}
-
 func TestInitTailFileFailsToWriteSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -128,7 +123,7 @@ func TestInitTailFileFailsToWriteSuccess(t *testing.T) {
 	c.AddCommand(initCmd)
 
 	// Create error from output
-	ew := &errorWriter{}
+	ew := testtools.NewErrorWriter()
 	c.SetOutput(ew)
 	initCmd.SetOutput(ew)
 

--- a/ginaudit/mdw.go
+++ b/ginaudit/mdw.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/metal-toolbox/auditevent"
 )
@@ -63,6 +64,21 @@ func NewJSONMiddleware(component string, w io.Writer) *Middleware {
 	)
 }
 
+// WithPrometheusMetrics enables prometheus metrics for this middleware instance
+// using the default prometheus registerer (prometheus.DefaultRegisterer).
+func (m *Middleware) WithPrometheusMetrics() *Middleware {
+	m.aew.WithPrometheusMetrics(m.component)
+	return m
+}
+
+// WithPrometheusMetricsForRegisterer enables prometheus metrics for this middleware instance
+// using the default prometheus registerer (prometheus.DefaultRegisterer).
+func (m *Middleware) WithPrometheusMetricsForRegisterer(pr prometheus.Registerer) *Middleware {
+	m.aew.WithPrometheusMetricsForRegisterer(m.component, pr)
+	return m
+}
+
+// RegisterEventType registers an audit event type for a given HTTP method and path.
 func (m *Middleware) RegisterEventType(eventType, httpMethod, path string) {
 	m.eventTypeMap.Store(keyFromHTTPMethodAndPath(httpMethod, path), eventType)
 }

--- a/internal/testtools/testtools.go
+++ b/internal/testtools/testtools.go
@@ -101,3 +101,14 @@ func ReadAllAuditEvents(t *testing.T, reader io.Reader, expectedEvents int) {
 		}
 	}
 }
+
+// ErrorWriter is a writer that always returns an error.
+type ErrorWriter struct{}
+
+func NewErrorWriter() io.Writer {
+	return &ErrorWriter{}
+}
+
+func (e *ErrorWriter) Write(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("error")
+}

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -17,6 +17,7 @@ package metrics_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -112,24 +113,28 @@ func TestPrometheusMetricsProvider_IncEvents(t *testing.T) {
 				case "regular":
 					switch m.GetName() {
 					case metrics.EventsTotalMetricsName:
-						metricToCompare = fmt.Sprintf("%s{component=%q}.*%d", metrics.EventsTotalMetricsName, component, totalEvents)
+						metricToCompare = fmt.Sprintf("%s{component=%q} %d\n",
+							metrics.EventsTotalMetricsName, component, totalEvents)
 					case metrics.ErrorsTotalMetricsName:
-						metricToCompare = fmt.Sprintf("%s{component=%q}.*%d", metrics.ErrorsTotalMetricsName, component, nSecondaryEvents)
+						metricToCompare = fmt.Sprintf("%s{component=%q} %d\n",
+							metrics.ErrorsTotalMetricsName, component, nSecondaryEvents)
 					default:
 						t.Errorf("unexpected metric name: %s", m.GetName())
 					}
 				case "error":
 					switch m.GetName() {
 					case metrics.EventsTotalMetricsName:
-						metricToCompare = fmt.Sprintf("%s{component=%q}.*%d", metrics.EventsTotalMetricsName, component, nSecondaryEvents)
+						metricToCompare = fmt.Sprintf("%s{component=%q} %d\n",
+							metrics.EventsTotalMetricsName, component, nSecondaryEvents)
 					case metrics.ErrorsTotalMetricsName:
-						metricToCompare = fmt.Sprintf("%s{component=%q}.*%d", metrics.ErrorsTotalMetricsName, component, totalEvents)
+						metricToCompare = fmt.Sprintf("%s{component=%q} %d\n",
+							metrics.ErrorsTotalMetricsName, component, totalEvents)
 					default:
 						t.Errorf("unexpected metric name: %s", m.GetName())
 					}
 				}
 
-				require.Regexp(t, metricToCompare, str)
+				require.Regexp(t, regexp.MustCompile(metricToCompare), str)
 			}
 		})
 	}


### PR DESCRIPTION
This takes the previously defined metrics interface (https://github.com/metal-toolbox/auditevent/pull/24) and embeds it in the `EventWriter` interface itself.

This now effectively captures metrics for any events or errors occurring through this library.

The prometheus metrics setup was also hooked up to the `Middleware`, making this easily usable in gin routers through the builder functions.
