### PR TITLE
Remove test dependency from build job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,6 @@ jobs:
 
   build-image:
     name: build-image
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 


### PR DESCRIPTION
The `build` job used to need the `step` job to finish in order to run. While this was a nice separation... e.g. we don't try to build a container if the test is not passing; this only slows down the CI process.

Let's run them in parallel now. We don't push images on the `build` process anyway.
