### PR TITLE
User major versions for some GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -73,12 +73,10 @@ jobs:
 
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v2.2.1
-        with:
-          cosign-release: v1.7.2
+        uses: sigstore/cosign-installer@v2
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -104,15 +102,13 @@ jobs:
 
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v2.2.1
-        with:
-          cosign-release: v1.7.2
+        uses: sigstore/cosign-installer@v2
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0.11.0
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -138,9 +134,7 @@ jobs:
 
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v2.2.1
-        with:
-          cosign-release: v1.7.2
+        uses: sigstore/cosign-installer@v2
 
       - name: Generate provenance
         uses: philips-labs/slsa-provenance-action@v0.7.2
@@ -154,7 +148,7 @@ jobs:
           IMAGE_TAGS: ${{ needs.container.outputs.image-tags }}
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
This allows us to get the latest and greatest without compromising much
backwards compatibility.

We also take the recommended version from the cosign installer action
since the one we were getting will now be superceded.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
