### PR TITLE
audittail: Use `ENTRYPOINT` instead of `CMD`

### DIFF
--- a/images/audittail/Containerfile
+++ b/images/audittail/Containerfile
@@ -13,4 +13,4 @@ RUN CGO_ENABLED=0 go build -o /go/bin/audittail cmds/audittail/main.go
 FROM gcr.io/distroless/static
 
 COPY --from=build-env /go/bin/audittail /
-CMD ["/audittail"]
+ENTRYPOINT ["/audittail"]


### PR DESCRIPTION
This ensure the audittail binary is always used and using `command` wil
merely add parameters to our default binary.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
