### PR TITLE
Stop pinning cosign release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,6 @@ jobs:
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@v2.3.0
-        with:
-          cosign-release: v1.7.2
 
       - name: Login to ghcr.io
         uses: docker/login-action@v1.14.1
@@ -105,8 +103,6 @@ jobs:
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@v2.3.0
-        with:
-          cosign-release: v1.7.2
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0.11.0
@@ -139,8 +135,6 @@ jobs:
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@v2.3.0
-        with:
-          cosign-release: v1.7.2
 
       - name: Generate provenance
         uses: philips-labs/slsa-provenance-action@v0.7.2


### PR DESCRIPTION
Instead, let's use the version recommended by the cosign-installer
action.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
