### PR TITLE
Call GitHub workflow to build a container image for each commit

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,0 +1,22 @@
+name: Release latest
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  container-main:
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: audittail
+      tag: ${GITHUB_REF_NAME}
+      dockerfile_path: images/audittail/Containerfile
+
+  # Push to latest
+  container-push-latest:
+    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
+    with:
+      name: audittail
+      tag: latest
+      dockerfile_path: images/audittail/Containerfile


### PR DESCRIPTION
this effectively builds `main` and `latest` for each commit to the
`main` branch.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
