### PR TITLE
Only build `latest` not latest and main

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -6,13 +6,6 @@ on:
       - main
 
 jobs:
-  container-main:
-    uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
-    with:
-      name: audittail
-      tag: ${GITHUB_REF_NAME}
-      dockerfile_path: images/audittail/Containerfile
-
   # Push to latest
   container-push-latest:
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main


### PR DESCRIPTION
We have a limitation where the image digest won't match if we try to
build them in different actions. We should ideally be able to pass one
or more tags in one action call.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
