### PR TITLE
audittail: Make init command idempotent

### DIFF
--- a/cmds/audittail/cmd/common.go
+++ b/cmds/audittail/cmd/common.go
@@ -16,7 +16,9 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -42,6 +44,10 @@ func validateCommonArgs(cmd *cobra.Command, args []string) error {
 
 func createNamedPipe(file string) error {
 	if err := syscall.Mkfifo(file, ownerGroupOwnership); err != nil {
+		// Don't fail if the file already exists.
+		if errors.Is(err, os.ErrExist) {
+			return nil
+		}
 		return fmt.Errorf("creating named pipe: %w", err)
 	}
 	return nil

--- a/cmds/audittail/cmd/init_test.go
+++ b/cmds/audittail/cmd/init_test.go
@@ -102,8 +102,7 @@ func TestInitTailFileFailsIfItCantCreateFIFO(t *testing.T) {
 	initCmd.SetOutput(buf)
 
 	// Set the arguments
-	tmpDir := t.TempDir()
-	args := append([]string{"-f"}, tmpDir)
+	args := append([]string{"-f"}, "/foo/bar/")
 
 	perr := initCmd.ParseFlags(args)
 	require.NoError(t, perr)

--- a/cmds/audittail/cmd/init_test.go
+++ b/cmds/audittail/cmd/init_test.go
@@ -139,3 +139,32 @@ func TestInitTailFileFailsToWriteSuccess(t *testing.T) {
 	require.ErrorContains(t, err, "writing to stdout",
 		"there should be an error and it should contain the expected message")
 }
+
+func TestInitSucceedsEvenIfFileAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	c := NewRootCmd()
+	buf := bytes.NewBufferString("")
+	c.SetOutput(buf)
+	c.AddCommand(NewInitCommand())
+
+	args := []string{"init", "-f"}
+	var path string
+
+	tmpDir := t.TempDir()
+	path = filepath.Join(tmpDir, "audit.log")
+	args = append(args, path)
+
+	c.SetArgs(args)
+	err := c.Execute()
+	require.NoError(t, err, "unexpected error")
+
+	_, serr := os.Stat(path)
+	require.NoError(t, serr, "unexpected error")
+	require.Contains(t, buf.String(), "Created named pipe")
+
+	// A second call should still succeed
+	c.SetArgs(args)
+	err = c.Execute()
+	require.NoError(t, err, "unexpected error in second call")
+}


### PR DESCRIPTION
We shouldn't fail if the named pipe is already there, we should just
assume it was pre-created and continue as always.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
