### PR TITLE
Add audit helper with context to allow for control from calling application

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -16,6 +16,8 @@ limitations under the License.
 package helpers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -35,16 +37,9 @@ const (
 // It assumes that audit events are less than 4096 bytes to ensure atomicity.
 // it takes a writer for the audit log.
 func OpenAuditLogFileUntilSuccess(path string, loggers ...logr.Logger) (*os.File, error) {
-	var l logr.Logger
-
-	if len(loggers) > 0 {
-		l = loggers[0]
-	} else {
-		z, err := zap.NewProduction()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create zap logger: %w", err)
-		}
-		l = zapr.NewLogger(z)
+	l, err := newLogger(loggers...)
+	if err != nil {
+		return nil, err
 	}
 
 	l.Info("opening audit log file. This will block until the file is available", "path", path)
@@ -67,4 +62,57 @@ func OpenAuditLogFileUntilSuccess(path string, loggers ...logr.Logger) (*os.File
 		l.Info("audit log file opened successfully", "path", path)
 		return fd, nil
 	}
+}
+
+// OpenAuditLogFileUntilSuccessWithContext attempts to open a file for writing audit events until
+// it succeeds or the context is cancelled.
+// It assumes that audit events are less than 4096 bytes to ensure atomicity.
+// it takes a writer for the audit log.
+func OpenAuditLogFileUntilSuccessWithContext(ctx context.Context, path string, ls ...logr.Logger) (*os.File, error) {
+	l, err := newLogger(ls...)
+	if err != nil {
+		return nil, err
+	}
+
+	l.Info("opening audit log file. This will block until the file is available or context is cancelled", "path", path)
+
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
+
+	for ; true; <-ticker.C {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		// This is opened with the O_APPEND option to ensure
+		// atomicity of writes. This is important to ensure
+		// we can concurrently write to the file and not block
+		// the server's main loop.
+		fd, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, ownerGroupAccess)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			// Not being able to write audit log events is a fatal error
+			return nil, err
+		}
+
+		l.Info("audit log file opened successfully", "path", path)
+		return fd, nil
+	}
+
+	return nil, errors.New("unexpected audit log error")
+}
+
+func newLogger(loggers ...logr.Logger) (logr.Logger, error) {
+	if len(loggers) > 0 {
+		return loggers[0], nil
+	}
+
+	z, err := zap.NewProduction()
+	if err != nil {
+		return logr.Logger{}, fmt.Errorf("failed to create zap logger: %w", err)
+	}
+
+	return zapr.NewLogger(z), nil
 }


### PR DESCRIPTION
This PR adds a new helper for opening the audit log with context.  The thought is we can respect os signals and gracefully exit when starting without an audit file instead of killing the process.