### PR TITLE
Set up configuration for Chainguard's enforce

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,10 @@
+---
+spec:
+  authorities:
+    # Accept all keyless signatures validated from the public sigstore instance.
+    # This is open source software after all. All we want to know is that the
+    # person that did the commit has control over their email address.
+    - keyless:
+    # Add this if you also want to allow commits signed by GitHub.
+    - key:
+        kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
This validates any email on the public sigstore instance (as it did
before) but also accepts gitHub's web-flow GPG signatures.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
