### PR TITLE
Fix chainguard enforce configuration

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -4,7 +4,7 @@ spec:
     # Accept all keyless signatures validated from the public sigstore instance.
     # This is open source software after all. All we want to know is that the
     # person that did the commit has control over their email address.
-    - keyless:
+    - keyless: {}
     # Add this if you also want to allow commits signed by GitHub.
     - key:
         kms: https://github.com/web-flow.gpg


### PR DESCRIPTION
instead of passing `nil` to the keyless configuration, this passes an
empty dict.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
