### PR TITLE
audittail: Add support for running as non-root

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,6 +24,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: 'fs'
+          security-checks: 'vuln,config,secret'
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
+          skip-dirs: 'tests'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,42 @@ jobs:
       
       - name: Inspect action SARIF report
         run: cat ${{ steps.scan.outputs.sarif }}
+
+  kube-test:
+    strategy:
+      matrix:
+        scenario: [nonroot, rootuser, allroot]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 
+        uses: actions/checkout@v3
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.3.0
+      
+      - name: Build image
+        run: make image
+      
+      - name: Load audittail image into kind cluster
+        run: kind load docker-image gchr.io/metal-toolbox/audittail:latest
+      
+      - name: Create Namespace
+        run: kubectl create namespace ${{ matrix.scenario }}
+      
+      - name: Deploy test scenario
+        run: kubectl apply -f tests/kube/scenarios/${{ matrix.scenario }}.yml -n ${{ matrix.scenario }}
+    
+      - name: Wait for readiness
+        run: kubectl wait --for=condition=ready --timeout=60s -n ${{ matrix.scenario }} pod myapp
+      
+      - name: Get logs
+        id: logs
+        run: kubectl logs -n ${{ matrix.scenario }} myapp -c audittail
+      
+      - name: Inspect logs
+        run: echo ${{ steps.logs.outputs.stdout }}
+      
+      - name: Check logs
+        run: |
+          echo ${{ steps.logs.outputs.stdout }} | grep "This is an audit log"
+          echo ${{ steps.logs.outputs.stdout }} | grep "This is an audit log" | wc -l | grep 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Wait for readiness
         run: kubectl wait --for=condition=ready --timeout=60s -n ${{ matrix.scenario }} pod myapp
       
+      - name: Get pod information
+        run: kubectl describe -n ${{ matrix.scenario }} pod myapp
+      
       - name: Get logs
         id: logs
         run: kubectl logs -n ${{ matrix.scenario }} myapp -c audittail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.3.0
+        with:
+          cluster_name: kind
       
       - name: Build image
         run: make image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,12 +98,14 @@ jobs:
       
       - name: Get logs
         id: logs
-        run: kubectl logs -n ${{ matrix.scenario }} myapp -c audittail
+        run: |
+          kubectl logs -n ${{ matrix.scenario }} myapp -c audittail
+          echo "::set-output name=auditlog::$(kubectl logs -n ${{ matrix.scenario }} myapp -c audittail)"
       
       - name: Inspect logs
-        run: echo ${{ steps.logs.outputs.stdout }}
+        run: echo ${{ steps.logs.outputs.auditlog }}
       
       - name: Check logs
         run: |
-          echo ${{ steps.logs.outputs.stdout }} | grep "This is an audit log"
-          echo ${{ steps.logs.outputs.stdout }} | grep "This is an audit log" | wc -l | grep 1
+          echo ${{ steps.logs.outputs.auditlog }} | grep "This is an audit log"
+          echo ${{ steps.logs.outputs.auditlog }} | grep "This is an audit log" | wc -l | grep 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,13 @@ jobs:
           context: .
           file: ./images/audittail/Dockerfile
           push: false
-          tags: gchr.io/metal-toolbox/audittail:latest
+          tags: ghcr.io/metal-toolbox/audittail:latest
 
       - name: Scan image
         id: scan
         uses: anchore/scan-action@v3
         with:
-          image: gchr.io/metal-toolbox/audittail:latest
+          image: ghcr.io/metal-toolbox/audittail:latest
           acs-report-enable: true
 
       - name: upload Anchore scan SARIF report
@@ -80,7 +80,7 @@ jobs:
         run: make image
       
       - name: Load audittail image into kind cluster
-        run: kind load docker-image gchr.io/metal-toolbox/audittail:latest
+        run: kind load docker-image ghcr.io/metal-toolbox/audittail:latest
       
       - name: Create Namespace
         run: kubectl create namespace ${{ matrix.scenario }}

--- a/images/audittail/Dockerfile
+++ b/images/audittail/Dockerfile
@@ -12,7 +12,8 @@ RUN CGO_ENABLED=0 go build -o /go/bin/audittail cmds/audittail/main.go
 
 FROM gcr.io/distroless/static:nonroot
 
-USER nonroot:nonroot
+# `nonroot` coming from distroless
+USER 65532:65532
 
 COPY --from=build-env /go/bin/audittail /
 ENTRYPOINT ["/audittail"]

--- a/images/audittail/Dockerfile
+++ b/images/audittail/Dockerfile
@@ -10,7 +10,9 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build -o /go/bin/audittail cmds/audittail/main.go 
 
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/static:nonroot
+
+USER nonroot:nonroot
 
 COPY --from=build-env /go/bin/audittail /
 ENTRYPOINT ["/audittail"]

--- a/tests/kube/scenarios/allroot.yml
+++ b/tests/kube/scenarios/allroot.yml
@@ -1,0 +1,53 @@
+---
+# This test scenario consists of verifying that the audittail
+# image works in a case where no user is root.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  initContainers:
+    - image: ghcr.io/metal-toolbox/audittail:latest
+      imagePullPolicy: Never
+      args:
+        - 'init'
+        - '-f'
+        - '/app-audit/audit.log'
+      name: init-audit-logs
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+  containers:
+    - name: myapp
+      image: busybox:stable
+      command: ['sh', '-c', 'echo This is an audit log > /app-audit/audit.log && touch /tmp/ready && sleep 3600']
+      readinessProbe:
+        exec:
+          command:
+          - cat
+          - /tmp/ready
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      resources:
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+    - name: audittail
+      image: ghcr.io/metal-toolbox/audittail:latest
+      imagePullPolicy: Never
+      args:
+        - '-f'
+        - '/app-audit/audit.log'
+      resources:
+        limits:
+          memory: "50Mi"
+          cpu: "500m"
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+  volumes:
+    - name: audit-logs
+      emptyDir: {}

--- a/tests/kube/scenarios/allroot.yml
+++ b/tests/kube/scenarios/allroot.yml
@@ -1,6 +1,7 @@
 ---
 # This test scenario consists of verifying that the audittail
-# image works in a case where no user is root.
+# image works in a case where no user is specified (root by default
+# on kubernetes).
 apiVersion: v1
 kind: Pod
 metadata:

--- a/tests/kube/scenarios/nonroot.yml
+++ b/tests/kube/scenarios/nonroot.yml
@@ -1,0 +1,57 @@
+---
+# This test scenario consists of verifying that the audittail
+# image works in a case where no user is root.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+  initContainers:
+    - image: ghcr.io/metal-toolbox/audittail:latest
+      imagePullPolicy: Never
+      args:
+        - 'init'
+        - '-f'
+        - '/app-audit/audit.log'
+      name: init-audit-logs
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+  containers:
+    - name: myapp
+      image: busybox:stable
+      command: ['sh', '-c', 'echo This is an audit log > /app-audit/audit.log && touch /tmp/ready && sleep 3600']
+      readinessProbe:
+        exec:
+          command:
+          - cat
+          - /tmp/ready
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      resources:
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+    - name: audittail
+      image: ghcr.io/metal-toolbox/audittail:latest
+      imagePullPolicy: Never
+      args:
+        - '-f'
+        - '/app-audit/audit.log'
+      resources:
+        limits:
+          memory: "50Mi"
+          cpu: "500m"
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+  volumes:
+    - name: audit-logs
+      emptyDir: {}

--- a/tests/kube/scenarios/rootuser.yml
+++ b/tests/kube/scenarios/rootuser.yml
@@ -1,6 +1,8 @@
 ---
 # This test scenario consists of verifying that the audittail
-# image works in a case where no user is root.
+# image works in a case where the user of the audittail image
+# (the main application itself) is using a root user, while audittail
+# is not.
 apiVersion: v1
 kind: Pod
 metadata:
@@ -24,7 +26,6 @@ spec:
   containers:
     - name: myapp
       image: busybox:stable
-      imagePullPolicy: Never
       command: ['sh', '-c', 'echo This is an audit log > /app-audit/audit.log && touch /tmp/ready && sleep 3600']
       readinessProbe:
         exec:

--- a/tests/kube/scenarios/rootuser.yml
+++ b/tests/kube/scenarios/rootuser.yml
@@ -1,0 +1,62 @@
+---
+# This test scenario consists of verifying that the audittail
+# image works in a case where no user is root.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp
+spec:
+  initContainers:
+    - image: ghcr.io/metal-toolbox/audittail:latest
+      imagePullPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+      args:
+        - 'init'
+        - '-f'
+        - '/app-audit/audit.log'
+      name: init-audit-logs
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+  containers:
+    - name: myapp
+      image: busybox:stable
+      imagePullPolicy: Never
+      command: ['sh', '-c', 'echo This is an audit log > /app-audit/audit.log && touch /tmp/ready && sleep 3600']
+      readinessProbe:
+        exec:
+          command:
+          - cat
+          - /tmp/ready
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      resources:
+        limits:
+          memory: "128Mi"
+          cpu: "500m"
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+    - name: audittail
+      image: ghcr.io/metal-toolbox/audittail:latest
+      imagePullPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+      args:
+        - '-f'
+        - '/app-audit/audit.log'
+      resources:
+        limits:
+          memory: "50Mi"
+          cpu: "500m"
+      volumeMounts:
+        - mountPath: /app-audit
+          name: audit-logs
+  volumes:
+    - name: audit-logs
+      emptyDir: {}

--- a/tests/kube/scenarios/rootuser.yml
+++ b/tests/kube/scenarios/rootuser.yml
@@ -13,8 +13,6 @@ spec:
       imagePullPolicy: Never
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
       args:
         - 'init'
         - '-f'
@@ -46,8 +44,6 @@ spec:
       imagePullPolicy: Never
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65532
-        runAsGroup: 65532
       args:
         - '-f'
         - '/app-audit/audit.log'


### PR DESCRIPTION
This adds support for the `audittail` container to run as a non-root user.

This relies on distroless' `nonroot` user which has the 65532 UID.

Subsequently, e2e tests were added that ensure this works as expected with several combinations.
