### PR TITLE
Add support for passing enrichment data to middleware via context

### DIFF
--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -72,6 +72,20 @@ When using the gin middleware, the audit ID will be added to the context and ava
 auditID := c.GetString(mdw.AuditIDContextKey)
 ```
 
+#### Addtional Data
+
+Additional audit data can be passed down to the audit middleware via the context key
+`AuditDataContextKey`.  This can be leveraged to enrich the audit events with
+diff information or other data for forensic analysis.  The value is expected to be
+a `*json.RawMessage` and you are responsible for ensuring proper JSON structure.
+
+```golang
+// add additional data to context to be logged in the
+// audit event by the middleware
+mydata := json.RawMessage(`{"foo":"bar"}`)
+c.Set(mdw.AuditDataContextKey, &mydata)
+```
+
 ### Audit event types
 
 Audit event types identify the action that happened on a given request.

--- a/ginaudit/mdw.go
+++ b/ginaudit/mdw.go
@@ -16,6 +16,7 @@ limitations under the License.
 package ginaudit
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
@@ -28,6 +29,8 @@ import (
 )
 
 const (
+	// AuditDataContextKey is the gin context key for additional audit data.
+	AuditDataContextKey = "audit.data"
 	// AuditIDContextKey is the gin context key for the audit ID.
 	AuditIDContextKey = "audit.id"
 )
@@ -124,6 +127,14 @@ func (m *Middleware) AuditWithType(t string) gin.HandlerFunc {
 		).WithTarget(map[string]string{
 			"path": path,
 		})
+
+		data, ok := c.Get(AuditDataContextKey)
+		if ok {
+			ed, ok := data.(*json.RawMessage)
+			if ok {
+				event.WithData(ed)
+			}
+		}
 
 		// persist event
 		m.write(event)

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,6 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220923202941-7f9b1623fab7 h1:ZrnxWX62AgTKOSagEqxvb3ffipvEDX2pl7E1TdqLqIc=
-golang.org/x/sync v0.0.0-20220923202941-7f9b1623fab7/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0 h1:cu5kTvlzcw1Q5S9f5ip1/cpiB4nXvw1XYzFPGgzLUOY=
 golang.org/x/sync v0.0.0-20220929204114-8fcdb60fdcc0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Allow middleware users to add audit data to the context and have it added to the event by the middleware.  This will be leveraged to add diffs, etc to our audit logs.