### PR TITLE
Set up renovate to auto-merge on minor and patch releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
I'm very comfortable with the test coverage for this library, so let's
set up Renovate to auto-merge on minor and patch releases (not major
ones) to reduce the maintenance burden.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
