### PR TITLE
Add release Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,17 @@ $(TOOLS_DIR)/golangci-lint: $(TOOLS_DIR)
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION
 	$(TOOLS_DIR)/golangci-lint version
 	$(TOOLS_DIR)/golangci-lint linters
+
+AUDITTAIL_IMAGE=ghcr.io/metal-toolbox/audittail
+
+.PHONY: release
+release: ## Issues a release
+	@test -n "$(TAG)" || (echo "The TAG variable must be set" && exit 1)
+	@echo "Releasing $(TAG)"
+	git checkout -b "release-$(TAG)"
+	sed -i -E s/v[0-9]+\.[0-9]+\.[0-9]+/$(TAG)/ charts/audittail/templates/_values.tpl
+	git add charts/audittail/templates/_values.tpl
+	git commit -m "Release $(TAG)"
+	git tag -m "Release $(TAG)" "$(TAG)"
+	git push origin "release-$(TAG)"
+	git push origin "$(TAG)"


### PR DESCRIPTION
Desc:

- Updating helm-library to use latest audittail container whenever there is a release, this effectively does a release by doing e.g. `TAG=v0.5.2 make release`.
