### PR TITLE
Add multi-arch build support for audittail

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -13,3 +13,4 @@ jobs:
       name: audittail
       tag: latest
       dockerfile_path: images/audittail/Dockerfile
+      platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,5 @@ jobs:
       name: audittail
       tag: ${GITHUB_REF_NAME}
       dockerfile_path: images/audittail/Dockerfile
+      platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
this requires https://github.com/metal-toolbox/container-push/pull/31
and when merged will add multi-arch builds to the audittail container
releases.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
