### PR TITLE
Use github context to set release ref name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: audittail
-      tag: ${GITHUB_REF_NAME}
+      tag: ${{ github.ref_name }}
       dockerfile_path: images/audittail/Dockerfile
       platforms: linux/amd64,linux/arm64
 


### PR DESCRIPTION
The environment variable is not being reflected, we should instead use
the ref name from the github context which should get evaluated.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
