### PR TITLE
To include process arguments in user section event

### DIFF
--- a/auditevent.go
+++ b/auditevent.go
@@ -155,7 +155,7 @@ func (e *AuditEvent) WithDataFromString(data string) *AuditEvent {
 	return e.WithData(&rawMsg)
 }
 
-// WithProcessArgs sets the process args of the event from a slice of string
+// WithProcessArgs sets the process args of the event from a slice of string.
 func (e *AuditEvent) WithProcessArgs(args []string) *AuditEvent {
 	e.Metadata.Extra["process_args"] = args
 	return e

--- a/auditevent.go
+++ b/auditevent.go
@@ -154,3 +154,9 @@ func (e *AuditEvent) WithDataFromString(data string) *AuditEvent {
 	rawMsg := json.RawMessage(data)
 	return e.WithData(&rawMsg)
 }
+
+// WithProcessArgs sets the process args of the event from a slice of string
+func (e *AuditEvent) WithProcessArgs(args []string) *AuditEvent {
+	e.Metadata.Extra["process_args"] = args
+	return e
+}


### PR DESCRIPTION
Desc:
This PR is to include process arguments in user section event

- UserAction event occurs when a user executes a program

[SCT-305](https://packet.atlassian.net/browse/SCT-305)
While working on [audito-maldito] has encounter the  below error so overcome those fixes raised this pull request.

Error:
https://github.com/metal-toolbox/audito-maldito/actions/runs/4687086322/jobs/8305935913#step:4:188